### PR TITLE
Fixed Step 4 - Mitigate the Vulnerability command: nano ~/vulnerable-…

### DIFF
--- a/textbook/09-WebApplicationAttacks.md
+++ b/textbook/09-WebApplicationAttacks.md
@@ -520,7 +520,7 @@ This chapter walked through the lifecycle of web-application security testing, b
 >#### Step 4 - Mitigate the Vulnerability
 >In a Kali VM bash terminal, open the `footer.php` file in the vulnerable-site/app directory using `nano` text editor.
 >```bash
->nano ~/vulnerable-site/app/home.php
+>nano ~/vulnerable-site/app/footer.php
 >```
 >Observe the last line renders the version from the supplied GET parameter without any input validation or output encoding. Update the last line by wrapping the `$_GET['version']` in the `htmlspecialchars` function. Press CTRL+X, Y for yes, and Enter to save over the exiting file.
 >```php


### PR DESCRIPTION
Hello I noticed a typo with one of the commands during Exercise 9.3 - Cross Site Scripting (XSS) on Step 4 - Mitigate the Vulnerability. The first command given is nano ~/vulnerable-site/app/home.php which leads to the wrong file to mitigate the XSS vulnerability. Luckily in the instructions above you mention footer.php so its not hard to debug. I have changed the command to direct nano to footer.php. Thank you for the awesome textbook and labs.